### PR TITLE
Change Hyper-V VM's disk configurations

### DIFF
--- a/template/customscripts/create-base-vhd-job.ps1
+++ b/template/customscripts/create-base-vhd-job.ps1
@@ -75,7 +75,7 @@ $params = @{
     VHDPath       = $vhdFilePath
     VHDFormat     = 'VHDX'
     DiskLayout    = 'UEFI'
-    SizeBytes     = 40GB
+    SizeBytes     = 500GB
     TempDirectory = $labConfig.labHost.folderPath.temp
     Verbose       = $true
 }

--- a/template/customscripts/create-vm-job-hcinode.ps1
+++ b/template/customscripts/create-vm-job-hcinode.ps1
@@ -242,7 +242,7 @@ Set-VMNetworkAdapter @paramsForSet |
 Set-VMNetworkAdapterVlan @paramsForVlan
 
 'Creating the data disks...' | Write-ScriptLog -Context $nodeConfig.VMName
-$diskCount = 6
+$diskCount = 8
 for ($diskIndex = 1; $diskIndex -le $diskCount; $diskIndex++) {
     $params = @{
         Path      = [IO.Path]::Combine($labConfig.labHost.folderPath.vm, $nodeConfig.VMName, ('datadisk{0}.vhdx' -f $diskIndex))

--- a/template/template.json
+++ b/template/template.json
@@ -529,7 +529,7 @@
                 "nodeCount": "[parameters('hciNodeCount')]",
                 "vmNameOffset": 1,
                 "vmName": "hcinode{0:00}",  // vmNameOffset + ZeroBasedNodeIndex
-                "dataDiskSizeBytes": 107374182400,
+                "dataDiskSizeBytes": 1099511627776,
                 "ipAddressOffset": 11,
                 "netAdapters": {
                     "management": {


### PR DESCRIPTION
- Increase Hyper-V VM's OS VHD size to 500 GB from 40 GB.
- Increase Hyper-V VM's data VHD size to 100 GB from 1 TB.
- Increase Hyper-V VM's data VHD count to 8 disks from 6 disks.