### PR TITLE
Change lab host OS to Windows Server 2025

### DIFF
--- a/template/customscripts/configure-lab-host.ps1
+++ b/template/customscripts/configure-lab-host.ps1
@@ -290,7 +290,7 @@ try {
         TargetPath       = 'C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe'
         Arguments        = 'https://{0}' -f $labConfig.wac.vmName  # The VM name is also the computer name.
         Description      = 'Open Windows Admin Center for your lab environment.'
-        IconLocation     = 'imageres.dll,1'
+        IconLocation     = 'imageres.dll,-1028'
     }
     New-ShortcutFile @params
     'Create a new shortcut on the desktop for accessing Windows Admin Center completed.' | Write-ScriptLog

--- a/template/customscripts/configure-lab-host.ps1
+++ b/template/customscripts/configure-lab-host.ps1
@@ -6,69 +6,6 @@ $WarningPreference = [Management.Automation.ActionPreference]::Continue
 $VerbosePreference = [Management.Automation.ActionPreference]::Continue
 $ProgressPreference = [Management.Automation.ActionPreference]::SilentlyContinue
 
-function Invoke-WindowsTerminalInstallation
-{
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [ValidateScript({ Test-Path -PathType Container -LiteralPath $_ })]
-        [string] $DownloadFolderPath
-    )
-
-    'Download the Windows 10 pre-install kit zip file.' | Write-ScriptLog
-    $params = @{
-        SourceUri      = 'https://github.com/microsoft/terminal/releases/download/v1.19.10821.0/Microsoft.WindowsTerminal_1.19.10821.0_8wekyb3d8bbwe.msixbundle_Windows10_PreinstallKit.zip'
-        DownloadFolder = $DownloadFolderPath
-        FileNameToSave = 'Microsoft.WindowsTerminal_Windows10_PreinstallKit.zip'
-    }
-    $zipFile = Invoke-FileDownload @params
-    'Download the Windows 10 pre-install kit zip file completed.' | Write-ScriptLog
-
-    'Expaned the Windows 10 pre-install kit zip file.' | Write-ScriptLog
-    $fileSourceFolder = [IO.Path]::Combine([IO.Path]::GetDirectoryName($zipFile.FullName), [IO.Path]::GetFileNameWithoutExtension($zipFile.FullName))
-    Expand-Archive -LiteralPath $zipFile.FullName -DestinationPath $fileSourceFolder -Force
-    'Expaned the Windows 10 pre-install kit zip file completed.' | Write-ScriptLog
-
-    # Retrieve the Windows Termainl intallation files.
-    $uiXamlAppxFile = Get-ChildItem -LiteralPath $fileSourceFolder -Filter 'Microsoft.UI.Xaml.*_x64__*.appx' | Select-Object -First 1
-    $msixBundleFile = Get-ChildItem -LiteralPath $fileSourceFolder -Filter '*.msixbundle' | Select-Object -First 1
-    $licenseXmlFile = Get-ChildItem -LiteralPath $fileSourceFolder -Filter '*_License1.xml' | Select-Object -First 1
-    'Windows Terminal installation files:' | Write-ScriptLog
-    'Microsoft.UI.Xaml: "{0}"' -f $uiXamlAppxFile.FullName | Write-ScriptLog
-    'Microsoft.WindowsTerminal: "{0}"' -f $msixBundleFile.FullName | Write-ScriptLog
-    'LicenseXml: "{0}"' -f $licenseXmlFile.FullName | Write-ScriptLog
-
-    'Install the dependency packages for Windows Terminal.' | Write-ScriptLog
-    Add-AppxProvisionedPackage -Online -SkipLicense -PackagePath $uiXamlAppxFile.FullName
-    'Install the dependency packages for Windows Terminal completed.' | Write-ScriptLog
-
-    'Create a script file for the scheduled task to install Windows Terminal.' | Write-ScriptLog
-    $scheduledTaskName = 'WindowsTermailInstallation'
-    $scheduledTaskScriptFileContent = @"
-(Get-Host).UI.RawUI.WindowTitle = 'Windows Terminal installation'
-Write-Host 'Finishing up the Windows Terminal installation...' -ForegroundColor Yellow
-Add-AppxProvisionedPackage -Online -PackagePath '{0}' -LicensePath '{1}'
-Disable-ScheduledTask -TaskName '{2}' -TaskPath '\'
-"@ -f $msixBundleFile.FullName, $licenseXmlFile.FullName, $scheduledTaskName
-    $scheduledTaskScriptFilePath = [IO.Path]::Combine($DownloadFolderPath, $scheduledTaskName + 'Task.ps1')
-    Set-Content -LiteralPath $scheduledTaskScriptFilePath -Value $scheduledTaskScriptFileContent -Force
-    'Create a script file for the scheduled task to install Windows Terminal completed.' | Write-ScriptLog
-
-    'Create a new scheduled task to install Windows Terminal.' | Write-ScriptLog
-    $adminUsername = Get-InstanceMetadata -FilterPath '/compute/osProfile/adminUsername' -LeafNode
-    $params = @{
-        TaskName = $scheduledTaskName
-        TaskPath = '\'
-        User     = $adminUsername
-        RunLevel = 'Highest'
-        Trigger  = New-ScheduledTaskTrigger -AtLogOn -User $adminUsername
-        Action   = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ('-NoLogo -NonInteractive -WindowStyle Minimized -File "{0}"' -f $scheduledTaskScriptFilePath)
-        Force    = $true
-    }
-    Register-ScheduledTask @params
-    'Create a new scheduled task to install Windows Terminal completed.' | Write-ScriptLog
-}
-
 function Invoke-VSCodeInstallation
 {
     [CmdletBinding()]
@@ -270,12 +207,6 @@ try {
     # Install tools
 
     $toolsToInstall = $labConfig.labHost.toolsToInstall -split ';'
-    if ($toolsToInstall -contains 'windowsterminal') {
-        'Execute the Windows Terminal installation pre-tasks.' | Write-ScriptLog
-        Invoke-WindowsTerminalInstallation -DownloadFolderPath $labConfig.labHost.folderPath.temp
-        'Execute the Windows Terminal installation pre-tasks completed.' | Write-ScriptLog
-    }
-
     if ($toolsToInstall -contains 'vscode') {
         'Install Visual Studio Code.' | Write-ScriptLog
         Invoke-VSCodeInstallation -DownloadFolderPath $labConfig.labHost.folderPath.temp

--- a/template/linkedtemplates/labhostvm.json
+++ b/template/linkedtemplates/labhostvm.json
@@ -218,13 +218,17 @@
                     "windowsConfiguration": {
                         "provisionVmAgent": true,
                         "enableAutomaticUpdates": true,
+                        // "patchSettings": {
+                        //     "patchMode": "AutomaticByPlatform",
+                        //     "automaticByPlatformSettings": {
+                        //         "rebootSetting": "Never"
+                        //     },
+                        //     "enableHotpatching": true,
+                        //     "assessmentMode": "ImageDefault"
+                        // }
                         "patchSettings": {
-                            "patchMode": "AutomaticByPlatform",
-                            "automaticByPlatformSettings": {
-                                "rebootSetting": "Never"
-                            },
-                            "enableHotpatching": true,
-                            "assessmentMode": "ImageDefault"
+                            "patchMode": "AutomaticByOS",
+                            "enableHotpatching": false
                         }
                     }
                 },
@@ -249,7 +253,8 @@
                     "imageReference": {
                         "publisher": "MicrosoftWindowsServer",
                         "offer": "WindowsServer",
-                        "sku": "2022-datacenter-azure-edition-hotpatch-smalldisk",
+                        // "sku": "2022-datacenter-azure-edition-hotpatch-smalldisk",
+                        "sku": "2025-datacenter-smalldisk-g2",
                         "version": "latest"
                     },
                     "copy": [

--- a/uiforms/uiform-jajp.json
+++ b/uiforms/uiform-jajp.json
@@ -467,27 +467,6 @@
                                     }
                                 },
                                 {
-                                    "name": "shouldInstallWindowsTerminal",
-                                    "type": "Microsoft.Common.OptionsGroup",
-                                    "visible": true,
-                                    "label": "Windows ターミナル",
-                                    "toolTip": "Windows ターミナルは、コマンド プロンプト、PowerShell、Linux 用 Windows サブシステム (WSL) 経由の bash など、使い慣れたコマンド ライン シェル用の最新のホスト アプリケーションです。<a href='https://learn.microsoft.com/windows/terminal'>詳細情報</a>",
-                                    "defaultValue": "インストールしない",
-                                    "constraints": {
-                                        "required": true,
-                                        "allowedValues": [
-                                            {
-                                                "label": "インストールする",
-                                                "value": true
-                                            },
-                                            {
-                                                "label": "インストールしない",
-                                                "value": false
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
                                     "name": "shouldInstallVisualStudioCode",
                                     "type": "Microsoft.Common.OptionsGroup",
                                     "visible": true,
@@ -2150,7 +2129,7 @@
                 "labHostVmDataDiskSize": "[steps('labHostVmDetails').dataVolumeSection.dataDiskSize]",
                 "labHostVmDataDiskCount": "[first(map(filter(steps('basics').getVmSkuArmApi.transformed.list, (vmsku) => equals(vmsku.name, steps('basics').vmSize)), (item) => item.maxDataDiskCount))]",
                 "hasEligibleWindowsServerLicense": "[steps('basics').azureHybridBenefitSection.hasEligibleWindowsServerLicense]",
-                "toolsToInstall": "[concat(if(steps('labHostVmDetails').toolsSection.shouldInstallWindowsTerminal, 'windowsterminal', ''), ';', if(steps('labHostVmDetails').toolsSection.shouldInstallVisualStudioCode, 'vscode', ''))]",
+                "toolsToInstall": "[concat(if(steps('labHostVmDetails').toolsSection.shouldInstallVisualStudioCode, 'vscode', ''), ';')]",
                 "shouldEnabledAutoshutdown": "[steps('labHostVmDetails').autoshutdownSection.shouldEnabledAutoshutdown]",
                 "autoshutdownTime": "[steps('labHostVmDetails').autoshutdownSection.shutdownTime]",
                 "autoshutdownTimeZone": "[steps('labHostVmDetails').autoshutdownSection.shutdownTimeZone]",

--- a/uiforms/uiform.json
+++ b/uiforms/uiform.json
@@ -467,27 +467,6 @@
                                     }
                                 },
                                 {
-                                    "name": "shouldInstallWindowsTerminal",
-                                    "type": "Microsoft.Common.OptionsGroup",
-                                    "visible": true,
-                                    "label": "Windows Terminal",
-                                    "toolTip": "Windows Terminal is a modern host application for the command-line shells you already love, like Command Prompt, PowerShell, and bash via Windows Subsystem for Linux (WSL). <a href='https://learn.microsoft.com/windows/terminal'>more</a>",
-                                    "defaultValue": "Not install",
-                                    "constraints": {
-                                        "required": true,
-                                        "allowedValues": [
-                                            {
-                                                "label": "Install",
-                                                "value": true
-                                            },
-                                            {
-                                                "label": "Not install",
-                                                "value": false
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
                                     "name": "shouldInstallVisualStudioCode",
                                     "type": "Microsoft.Common.OptionsGroup",
                                     "visible": true,
@@ -2150,7 +2129,7 @@
                 "labHostVmDataDiskSize": "[steps('labHostVmDetails').dataVolumeSection.dataDiskSize]",
                 "labHostVmDataDiskCount": "[first(map(filter(steps('basics').getVmSkuArmApi.transformed.list, (vmsku) => equals(vmsku.name, steps('basics').vmSize)), (item) => item.maxDataDiskCount))]",
                 "hasEligibleWindowsServerLicense": "[steps('basics').azureHybridBenefitSection.hasEligibleWindowsServerLicense]",
-                "toolsToInstall": "[concat(if(steps('labHostVmDetails').toolsSection.shouldInstallWindowsTerminal, 'windowsterminal', ''), ';', if(steps('labHostVmDetails').toolsSection.shouldInstallVisualStudioCode, 'vscode', ''))]",
+                "toolsToInstall": "[concat(if(steps('labHostVmDetails').toolsSection.shouldInstallVisualStudioCode, 'vscode', ''), ';')]",
                 "shouldEnabledAutoshutdown": "[steps('labHostVmDetails').autoshutdownSection.shouldEnabledAutoshutdown]",
                 "autoshutdownTime": "[steps('labHostVmDetails').autoshutdownSection.shutdownTime]",
                 "autoshutdownTimeZone": "[steps('labHostVmDetails').autoshutdownSection.shutdownTimeZone]",


### PR DESCRIPTION
- Change the lab host OS to Windows Server 2025.
- Remove Windows Terminal installation option because Windows Server 2025 has Windows Terminal by default.