### PR TITLE
Disable WAC deploy temporary

### DIFF
--- a/template/customscripts/configure-lab-host.ps1
+++ b/template/customscripts/configure-lab-host.ps1
@@ -214,7 +214,7 @@ try {
     }
 
     # Shortcuts: Windows Admin Center
-
+    <#
     'Create a new shortcut on the desktop for accessing Windows Admin Center.' | Write-ScriptLog
     $params = @{
         ShortcutFilePath = 'C:\Users\Public\Desktop\Windows Admin Center.lnk'
@@ -225,7 +225,7 @@ try {
     }
     New-ShortcutFile @params
     'Create a new shortcut on the desktop for accessing Windows Admin Center completed.' | Write-ScriptLog
-
+    #>
     # Shortcuts: Remote Desktop connection
 
     'Create a new shortcut on the desktop for connecting to the management server using Remote Desktop connection.' | Write-ScriptLog

--- a/template/customscripts/create-hci-cluster.ps1
+++ b/template/customscripts/create-hci-cluster.ps1
@@ -450,7 +450,7 @@ try {
         'Clean up CIM sessions completed.' | Write-ScriptLog
     } | Out-String | Write-ScriptLog
     'Create a volume on S2D completed.' | Write-ScriptLog
-
+    <#
     'Import a WAC connection for the HCI cluster.' | Write-ScriptLog
     $params = @{
         InputObject = [PSCustomObject] @{
@@ -486,7 +486,7 @@ try {
         'Delete the connection list file completed.' | Write-ScriptLog
     } | Out-String | Write-ScriptLog
     'Import a WAC connection for the HCI cluster completed.' | Write-ScriptLog
-
+    #>
     'Clean up the PowerShell Direct session for the management server.' | Write-ScriptLog
     Invoke-PSDirectSessionCleanup -Session $wacDomainAdminCredPSSession -CommonModuleFilePathInVM $commonModuleFilePathInVM
     'Clean up the PowerShell Direct session for the management server completed.' | Write-ScriptLog

--- a/template/customscripts/create-vm-job-wac.ps1
+++ b/template/customscripts/create-vm-job-wac.ps1
@@ -314,6 +314,7 @@ try {
     'Configure network settings within the VM completed.' | Write-ScriptLog
 
     # Windows Admin Center
+    <#
 
     'Donwload the Windows Admin Center installer.' | Write-ScriptLog
     $wacInstallerFile = Invoke-WindowsAdminCenterInstallerDownload -DownloadFolderPath $labConfig.labHost.folderPath.temp
@@ -481,7 +482,7 @@ try {
         'Create the shortcut for Windows Admin Center on the desktop completed.' | Write-ScriptLog
     } | Out-String | Write-ScriptLog
     'Install Windows Admin Center within the VM completed.' | Write-ScriptLog
-
+    #>
     'Create a new shortcut on the desktop for connecting to the first HCI node using Remote Desktop connection.' | Write-ScriptLog
     $params = @{
         InputObject = [PSCustomObject] @{
@@ -568,7 +569,7 @@ try {
     'Setup the PowerShell Direct session.' | Write-ScriptLog
     Invoke-PSDirectSessionSetup -Session $domainAdminCredPSSession -CommonModuleFilePathInVM $commonModuleFilePathInVM
     'Setup the PowerShell Direct session completed.' | Write-ScriptLog
-
+    <#
     # NOTE: To preset WAC connections for the domain Administrator, the preset operation is required by
     # the domain Administrator because WAC connections are managed based on each user.
     'Configure Windows Admin Center for the domain Administrator.' | Write-ScriptLog
@@ -630,7 +631,7 @@ try {
         'Delete the Windows Admin Center connection list file completed.' | Write-ScriptLog
     } | Out-String | Write-ScriptLog
     'Configure Windows Admin Center for the domain Administrator completed.' | Write-ScriptLog
-
+    #>
     'Clean up the PowerShell Direct session.' | Write-ScriptLog
     Invoke-PSDirectSessionCleanup -Session $domainAdminCredPSSession -CommonModuleFilePathInVM $commonModuleFilePathInVM
     'Clean up the PowerShell Direct session completed.' | Write-ScriptLog


### PR DESCRIPTION
Disable WAC deploy temporary because the new WAC (2410) has a new installer.